### PR TITLE
Replace numbers and better wordbreaks

### DIFF
--- a/nominat/__init__.py
+++ b/nominat/__init__.py
@@ -4,7 +4,7 @@ import random
 import re
 
 SPLIT_UNDERSCORE = re.compile(r'[^_]+')
-SPLIT_CASED_WORDS = re.compile(r'(^[a-z]+|[A-Z]+(?![a-z])|[A-Z][a-z]+)')
+SPLIT_CASED_WORDS = re.compile(r'(^[a-z]+|[A-Z]+(?![a-z])|[A-Z][a-z]+|[0-9]+)')
 
 
 class Nominator(object):
@@ -36,13 +36,13 @@ class Nominator(object):
         Expects words to be of a detectable case: `lower`, `upper` or `title`.
         If a mixed case-style word is provided, a ValueError is raised instead.
         """
-        if word.islower():
+        if word.islower() or word.isdigit():
             return self._replace(word)
         elif word.isupper():
             return self._replace(word.lower()).upper()
         elif word.istitle():
             return self._replace(word.lower()).title()
-        raise ValueError('Unexpected word casing.')
+        raise ValueError('Unable to detect/reproduce case of %r.' % word)
 
     def _process_cased_words(self, match):
         """Replace the words within a single phrase portion."""

--- a/nominat/__init__.py
+++ b/nominat/__init__.py
@@ -3,7 +3,7 @@ import os
 import random
 import re
 
-SPLIT_UNDERSCORE = re.compile(r'[^_]+')
+SPLIT_BOUNDARIES = re.compile(r'[A-Za-z0-9]+')
 SPLIT_CASED_WORDS = re.compile(r'(^[a-z]+|[A-Z]+(?![a-z])|[A-Z][a-z]+|[0-9]+)')
 
 
@@ -28,7 +28,7 @@ class Nominator(object):
         replaces each individual word. The case style for each replaced word
         is kept the same as the original.
         """
-        return SPLIT_UNDERSCORE.sub(self._process_cased_words, word)
+        return SPLIT_BOUNDARIES.sub(self._process_cased_words, word)
 
     def replace_single(self, word):
         """Returns the replaced word in the same case style.

--- a/nominat/tests/test_nominat.py
+++ b/nominat/tests/test_nominat.py
@@ -79,6 +79,13 @@ def test_mixed_case_underscore(chicken, spam):
     assert chicken('some_PascalCase_and_camelCase') == chicken_result
 
 
+def test_replace_numerals(chicken, empty):
+    """Numbers are also replaced, with lowercase replacement words."""
+    assert chicken('Summer69') == 'Chickenchicken'
+    empty.cache.update({'version': 'plane', '3': 'fan'})
+    assert empty('VERSION_3') == 'PLANE_fan'
+
+
 def test_no_replace(chicken, spam):
     """Test that provided 'safe' words are not replaced."""
     assert chicken('table_id') == 'chicken_id'

--- a/nominat/tests/test_nominat.py
+++ b/nominat/tests/test_nominat.py
@@ -86,6 +86,11 @@ def test_replace_numerals(chicken, empty):
     assert empty('VERSION_3') == 'PLANE_fan'
 
 
+def test_word_boundaries(chicken):
+    """Everything that is not text to be replaced is preserved."""
+    expected = 'Chicken (chicken) chicken:chicken'
+    assert chicken('This (super) neat:thing') == expected
+
 def test_no_replace(chicken, spam):
     """Test that provided 'safe' words are not replaced."""
     assert chicken('table_id') == 'chicken_id'

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = open(os.path.join(HERE, 'README.rst')).read()
 
 setup(
     name='nominat',
-    version='0.1',
+    version='0.2',
     author='Elmer de Looff',
     author_email='elmer.delooff@gmail.com',
     description='Case-insensitive case-preserving variable name mangler',


### PR DESCRIPTION
Adds support for replacing numbers in provided strings, as well as breaking input strings on boundaries other than underscores. This allow any (ASCII) text to be replaced in a single call to `Nominat`.
